### PR TITLE
chore(upstream): bump strongdm terraform provider and regenerate SDKs

### DIFF
--- a/provider/cmd/pulumi-resource-sdm/schema.json
+++ b/provider/cmd/pulumi-resource-sdm/schema.json
@@ -24890,8 +24890,7 @@
                     "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuth:ResourceMcpGatewayOAuth"
                 },
                 "mcpGatewayOAuthDcr": {
-                    "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr",
-                    "description": "MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump."
+                    "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr"
                 },
                 "mcpGatewayPat": {
                     "$ref": "#/types/sdm:index/ResourceMcpGatewayPat:ResourceMcpGatewayPat"
@@ -25257,8 +25256,7 @@
                     "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuth:ResourceMcpGatewayOAuth"
                 },
                 "mcpGatewayOAuthDcr": {
-                    "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr",
-                    "description": "MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump."
+                    "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr"
                 },
                 "mcpGatewayPat": {
                     "$ref": "#/types/sdm:index/ResourceMcpGatewayPat:ResourceMcpGatewayPat"
@@ -25626,8 +25624,7 @@
                         "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuth:ResourceMcpGatewayOAuth"
                     },
                     "mcpGatewayOAuthDcr": {
-                        "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr",
-                        "description": "MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump."
+                        "$ref": "#/types/sdm:index/ResourceMcpGatewayOAuthDcr:ResourceMcpGatewayOAuthDcr"
                     },
                     "mcpGatewayPat": {
                         "$ref": "#/types/sdm:index/ResourceMcpGatewayPat:ResourceMcpGatewayPat"

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.129.2
 	github.com/pulumi/pulumi/sdk/v3 v3.236.0
-	github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260421084346-f6bd8cf99bb4
+	github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260429101441-e76a4cb1e40b
 )
 
 require (

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3977,8 +3977,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260421084346-f6bd8cf99bb4 h1:aIKz1YRD5WUnBuPSMerFJRPlNn4VHPToyTMXslhgYNY=
-github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260421084346-f6bd8cf99bb4/go.mod h1:bMUqB5nJVO/f/hZpHB8E/7nXsHkrsR3cAdT2rNH7gnw=
+github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260429101441-e76a4cb1e40b h1:fcOXakWhhkcRtVjWT+G3uvICtyRfh1AT9q7fzrdQPBw=
+github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260429101441-e76a4cb1e40b/go.mod h1:bMUqB5nJVO/f/hZpHB8E/7nXsHkrsR3cAdT2rNH7gnw=
 github.com/substrait-io/substrait-go v0.4.2/go.mod h1:qhpnLmrcvAnlZsUyPXZRqldiHapPTXC3t7xFgDi3aQg=
 github.com/teekennedy/goldmark-markdown v0.3.0 h1:ik9/biVGCwGWFg8dQ3KVm2pQ/wiiG0whYiUcz9xH0W8=
 github.com/teekennedy/goldmark-markdown v0.3.0/go.mod h1:kMhDz8La77A9UHvJGsxejd0QUflN9sS+QXCqnhmxmNo=

--- a/sdk/dotnet/Resource.cs
+++ b/sdk/dotnet/Resource.cs
@@ -325,9 +325,6 @@ namespace PiersKarsenbarg.Sdm
         [Output("mcpGatewayOAuth")]
         public Output<Outputs.ResourceMcpGatewayOAuth?> McpGatewayOAuth { get; private set; } = null!;
 
-        /// <summary>
-        /// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        /// </summary>
         [Output("mcpGatewayOAuthDcr")]
         public Output<Outputs.ResourceMcpGatewayOAuthDcr?> McpGatewayOAuthDcr { get; private set; } = null!;
 
@@ -744,9 +741,6 @@ namespace PiersKarsenbarg.Sdm
         [Input("mcpGatewayOAuth")]
         public Input<Inputs.ResourceMcpGatewayOAuthArgs>? McpGatewayOAuth { get; set; }
 
-        /// <summary>
-        /// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        /// </summary>
         [Input("mcpGatewayOAuthDcr")]
         public Input<Inputs.ResourceMcpGatewayOAuthDcrArgs>? McpGatewayOAuthDcr { get; set; }
 
@@ -1124,9 +1118,6 @@ namespace PiersKarsenbarg.Sdm
         [Input("mcpGatewayOAuth")]
         public Input<Inputs.ResourceMcpGatewayOAuthGetArgs>? McpGatewayOAuth { get; set; }
 
-        /// <summary>
-        /// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        /// </summary>
         [Input("mcpGatewayOAuthDcr")]
         public Input<Inputs.ResourceMcpGatewayOAuthDcrGetArgs>? McpGatewayOAuthDcr { get; set; }
 

--- a/sdk/go/sdm/resource.go
+++ b/sdk/go/sdm/resource.go
@@ -184,12 +184,11 @@ type Resource struct {
 	Maria                       ResourceMariaPtrOutput                       `pulumi:"maria"`
 	McpGatewayNoAuth            ResourceMcpGatewayNoAuthPtrOutput            `pulumi:"mcpGatewayNoAuth"`
 	McpGatewayOAuth             ResourceMcpGatewayOAuthPtrOutput             `pulumi:"mcpGatewayOAuth"`
-	// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-	McpGatewayOAuthDcr ResourceMcpGatewayOAuthDcrPtrOutput `pulumi:"mcpGatewayOAuthDcr"`
-	McpGatewayPat      ResourceMcpGatewayPatPtrOutput      `pulumi:"mcpGatewayPat"`
-	Memcached          ResourceMemcachedPtrOutput          `pulumi:"memcached"`
-	Memsql             ResourceMemsqlPtrOutput             `pulumi:"memsql"`
-	MongoHost          ResourceMongoHostPtrOutput          `pulumi:"mongoHost"`
+	McpGatewayOAuthDcr          ResourceMcpGatewayOAuthDcrPtrOutput          `pulumi:"mcpGatewayOAuthDcr"`
+	McpGatewayPat               ResourceMcpGatewayPatPtrOutput               `pulumi:"mcpGatewayPat"`
+	Memcached                   ResourceMemcachedPtrOutput                   `pulumi:"memcached"`
+	Memsql                      ResourceMemsqlPtrOutput                      `pulumi:"memsql"`
+	MongoHost                   ResourceMongoHostPtrOutput                   `pulumi:"mongoHost"`
 	// MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
 	MongoLegacyHost ResourceMongoLegacyHostPtrOutput `pulumi:"mongoLegacyHost"`
 	// MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
@@ -347,12 +346,11 @@ type resourceState struct {
 	Maria                       *ResourceMaria                       `pulumi:"maria"`
 	McpGatewayNoAuth            *ResourceMcpGatewayNoAuth            `pulumi:"mcpGatewayNoAuth"`
 	McpGatewayOAuth             *ResourceMcpGatewayOAuth             `pulumi:"mcpGatewayOAuth"`
-	// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-	McpGatewayOAuthDcr *ResourceMcpGatewayOAuthDcr `pulumi:"mcpGatewayOAuthDcr"`
-	McpGatewayPat      *ResourceMcpGatewayPat      `pulumi:"mcpGatewayPat"`
-	Memcached          *ResourceMemcached          `pulumi:"memcached"`
-	Memsql             *ResourceMemsql             `pulumi:"memsql"`
-	MongoHost          *ResourceMongoHost          `pulumi:"mongoHost"`
+	McpGatewayOAuthDcr          *ResourceMcpGatewayOAuthDcr          `pulumi:"mcpGatewayOAuthDcr"`
+	McpGatewayPat               *ResourceMcpGatewayPat               `pulumi:"mcpGatewayPat"`
+	Memcached                   *ResourceMemcached                   `pulumi:"memcached"`
+	Memsql                      *ResourceMemsql                      `pulumi:"memsql"`
+	MongoHost                   *ResourceMongoHost                   `pulumi:"mongoHost"`
 	// MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
 	MongoLegacyHost *ResourceMongoLegacyHost `pulumi:"mongoLegacyHost"`
 	// MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
@@ -481,12 +479,11 @@ type ResourceState struct {
 	Maria                       ResourceMariaPtrInput
 	McpGatewayNoAuth            ResourceMcpGatewayNoAuthPtrInput
 	McpGatewayOAuth             ResourceMcpGatewayOAuthPtrInput
-	// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-	McpGatewayOAuthDcr ResourceMcpGatewayOAuthDcrPtrInput
-	McpGatewayPat      ResourceMcpGatewayPatPtrInput
-	Memcached          ResourceMemcachedPtrInput
-	Memsql             ResourceMemsqlPtrInput
-	MongoHost          ResourceMongoHostPtrInput
+	McpGatewayOAuthDcr          ResourceMcpGatewayOAuthDcrPtrInput
+	McpGatewayPat               ResourceMcpGatewayPatPtrInput
+	Memcached                   ResourceMemcachedPtrInput
+	Memsql                      ResourceMemsqlPtrInput
+	MongoHost                   ResourceMongoHostPtrInput
 	// MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
 	MongoLegacyHost ResourceMongoLegacyHostPtrInput
 	// MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
@@ -619,12 +616,11 @@ type resourceArgs struct {
 	Maria                       *ResourceMaria                       `pulumi:"maria"`
 	McpGatewayNoAuth            *ResourceMcpGatewayNoAuth            `pulumi:"mcpGatewayNoAuth"`
 	McpGatewayOAuth             *ResourceMcpGatewayOAuth             `pulumi:"mcpGatewayOAuth"`
-	// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-	McpGatewayOAuthDcr *ResourceMcpGatewayOAuthDcr `pulumi:"mcpGatewayOAuthDcr"`
-	McpGatewayPat      *ResourceMcpGatewayPat      `pulumi:"mcpGatewayPat"`
-	Memcached          *ResourceMemcached          `pulumi:"memcached"`
-	Memsql             *ResourceMemsql             `pulumi:"memsql"`
-	MongoHost          *ResourceMongoHost          `pulumi:"mongoHost"`
+	McpGatewayOAuthDcr          *ResourceMcpGatewayOAuthDcr          `pulumi:"mcpGatewayOAuthDcr"`
+	McpGatewayPat               *ResourceMcpGatewayPat               `pulumi:"mcpGatewayPat"`
+	Memcached                   *ResourceMemcached                   `pulumi:"memcached"`
+	Memsql                      *ResourceMemsql                      `pulumi:"memsql"`
+	MongoHost                   *ResourceMongoHost                   `pulumi:"mongoHost"`
 	// MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
 	MongoLegacyHost *ResourceMongoLegacyHost `pulumi:"mongoLegacyHost"`
 	// MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
@@ -754,12 +750,11 @@ type ResourceArgs struct {
 	Maria                       ResourceMariaPtrInput
 	McpGatewayNoAuth            ResourceMcpGatewayNoAuthPtrInput
 	McpGatewayOAuth             ResourceMcpGatewayOAuthPtrInput
-	// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-	McpGatewayOAuthDcr ResourceMcpGatewayOAuthDcrPtrInput
-	McpGatewayPat      ResourceMcpGatewayPatPtrInput
-	Memcached          ResourceMemcachedPtrInput
-	Memsql             ResourceMemsqlPtrInput
-	MongoHost          ResourceMongoHostPtrInput
+	McpGatewayOAuthDcr          ResourceMcpGatewayOAuthDcrPtrInput
+	McpGatewayPat               ResourceMcpGatewayPatPtrInput
+	Memcached                   ResourceMemcachedPtrInput
+	Memsql                      ResourceMemsqlPtrInput
+	MongoHost                   ResourceMongoHostPtrInput
 	// MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
 	MongoLegacyHost ResourceMongoLegacyHostPtrInput
 	// MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
@@ -1199,7 +1194,6 @@ func (o ResourceOutput) McpGatewayOAuth() ResourceMcpGatewayOAuthPtrOutput {
 	return o.ApplyT(func(v *Resource) ResourceMcpGatewayOAuthPtrOutput { return v.McpGatewayOAuth }).(ResourceMcpGatewayOAuthPtrOutput)
 }
 
-// MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
 func (o ResourceOutput) McpGatewayOAuthDcr() ResourceMcpGatewayOAuthDcrPtrOutput {
 	return o.ApplyT(func(v *Resource) ResourceMcpGatewayOAuthDcrPtrOutput { return v.McpGatewayOAuthDcr }).(ResourceMcpGatewayOAuthDcrPtrOutput)
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -199,9 +199,6 @@ export class Resource extends pulumi.CustomResource {
     declare public readonly maria: pulumi.Output<outputs.ResourceMaria | undefined>;
     declare public readonly mcpGatewayNoAuth: pulumi.Output<outputs.ResourceMcpGatewayNoAuth | undefined>;
     declare public readonly mcpGatewayOAuth: pulumi.Output<outputs.ResourceMcpGatewayOAuth | undefined>;
-    /**
-     * MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-     */
     declare public readonly mcpGatewayOAuthDcr: pulumi.Output<outputs.ResourceMcpGatewayOAuthDcr | undefined>;
     declare public readonly mcpGatewayPat: pulumi.Output<outputs.ResourceMcpGatewayPat | undefined>;
     declare public readonly memcached: pulumi.Output<outputs.ResourceMemcached | undefined>;
@@ -618,9 +615,6 @@ export interface ResourceState {
     maria?: pulumi.Input<inputs.ResourceMaria | undefined>;
     mcpGatewayNoAuth?: pulumi.Input<inputs.ResourceMcpGatewayNoAuth | undefined>;
     mcpGatewayOAuth?: pulumi.Input<inputs.ResourceMcpGatewayOAuth | undefined>;
-    /**
-     * MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-     */
     mcpGatewayOAuthDcr?: pulumi.Input<inputs.ResourceMcpGatewayOAuthDcr | undefined>;
     mcpGatewayPat?: pulumi.Input<inputs.ResourceMcpGatewayPat | undefined>;
     memcached?: pulumi.Input<inputs.ResourceMemcached | undefined>;
@@ -783,9 +777,6 @@ export interface ResourceArgs {
     maria?: pulumi.Input<inputs.ResourceMaria | undefined>;
     mcpGatewayNoAuth?: pulumi.Input<inputs.ResourceMcpGatewayNoAuth | undefined>;
     mcpGatewayOAuth?: pulumi.Input<inputs.ResourceMcpGatewayOAuth | undefined>;
-    /**
-     * MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-     */
     mcpGatewayOAuthDcr?: pulumi.Input<inputs.ResourceMcpGatewayOAuthDcr | undefined>;
     mcpGatewayPat?: pulumi.Input<inputs.ResourceMcpGatewayPat | undefined>;
     memcached?: pulumi.Input<inputs.ResourceMemcached | undefined>;

--- a/sdk/python/pierskarsenbarg_pulumi_sdm/resource.py
+++ b/sdk/python/pierskarsenbarg_pulumi_sdm/resource.py
@@ -145,7 +145,6 @@ class ResourceArgs:
         :param pulumi.Input['ResourceDocumentDbReplicaSetIamArgs'] document_db_replica_set_iam: DocumentDBReplicaSetIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceElasticacheRedisIamArgs'] elasticache_redis_iam: ElasticacheRedisIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceKubernetesBasicAuthArgs'] kubernetes_basic_auth: KubernetesBasicAuth is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        :param pulumi.Input['ResourceMcpGatewayOAuthDcrArgs'] mcp_gateway_o_auth_dcr: MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceMongoLegacyHostArgs'] mongo_legacy_host: MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceMongoLegacyReplicasetArgs'] mongo_legacy_replicaset: MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
         """
@@ -1084,9 +1083,6 @@ class ResourceArgs:
     @_builtins.property
     @pulumi.getter(name="mcpGatewayOAuthDcr")
     def mcp_gateway_o_auth_dcr(self) -> pulumi.Input[Optional['ResourceMcpGatewayOAuthDcrArgs']]:
-        """
-        MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        """
         return pulumi.get(self, "mcp_gateway_o_auth_dcr")
 
     @mcp_gateway_o_auth_dcr.setter
@@ -1614,7 +1610,6 @@ class _ResourceState:
         :param pulumi.Input['ResourceDocumentDbReplicaSetIamArgs'] document_db_replica_set_iam: DocumentDBReplicaSetIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceElasticacheRedisIamArgs'] elasticache_redis_iam: ElasticacheRedisIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceKubernetesBasicAuthArgs'] kubernetes_basic_auth: KubernetesBasicAuth is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        :param pulumi.Input['ResourceMcpGatewayOAuthDcrArgs'] mcp_gateway_o_auth_dcr: MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceMongoLegacyHostArgs'] mongo_legacy_host: MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input['ResourceMongoLegacyReplicasetArgs'] mongo_legacy_replicaset: MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
         """
@@ -2553,9 +2548,6 @@ class _ResourceState:
     @_builtins.property
     @pulumi.getter(name="mcpGatewayOAuthDcr")
     def mcp_gateway_o_auth_dcr(self) -> pulumi.Input[Optional['ResourceMcpGatewayOAuthDcrArgs']]:
-        """
-        MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        """
         return pulumi.get(self, "mcp_gateway_o_auth_dcr")
 
     @mcp_gateway_o_auth_dcr.setter
@@ -3146,7 +3138,6 @@ class Resource(pulumi.CustomResource):
         :param pulumi.Input[Union['ResourceDocumentDbReplicaSetIamArgs', 'ResourceDocumentDbReplicaSetIamArgsDict']] document_db_replica_set_iam: DocumentDBReplicaSetIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceElasticacheRedisIamArgs', 'ResourceElasticacheRedisIamArgsDict']] elasticache_redis_iam: ElasticacheRedisIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceKubernetesBasicAuthArgs', 'ResourceKubernetesBasicAuthArgsDict']] kubernetes_basic_auth: KubernetesBasicAuth is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        :param pulumi.Input[Union['ResourceMcpGatewayOAuthDcrArgs', 'ResourceMcpGatewayOAuthDcrArgsDict']] mcp_gateway_o_auth_dcr: MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceMongoLegacyHostArgs', 'ResourceMongoLegacyHostArgsDict']] mongo_legacy_host: MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceMongoLegacyReplicasetArgs', 'ResourceMongoLegacyReplicasetArgsDict']] mongo_legacy_replicaset: MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
         """
@@ -3612,7 +3603,6 @@ class Resource(pulumi.CustomResource):
         :param pulumi.Input[Union['ResourceDocumentDbReplicaSetIamArgs', 'ResourceDocumentDbReplicaSetIamArgsDict']] document_db_replica_set_iam: DocumentDBReplicaSetIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceElasticacheRedisIamArgs', 'ResourceElasticacheRedisIamArgsDict']] elasticache_redis_iam: ElasticacheRedisIAM is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceKubernetesBasicAuthArgs', 'ResourceKubernetesBasicAuthArgsDict']] kubernetes_basic_auth: KubernetesBasicAuth is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        :param pulumi.Input[Union['ResourceMcpGatewayOAuthDcrArgs', 'ResourceMcpGatewayOAuthDcrArgsDict']] mcp_gateway_o_auth_dcr: MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceMongoLegacyHostArgs', 'ResourceMongoLegacyHostArgsDict']] mongo_legacy_host: MongoLegacyHost is currently unstable, and its API may change, or it may be removed, without a major version bump.
         :param pulumi.Input[Union['ResourceMongoLegacyReplicasetArgs', 'ResourceMongoLegacyReplicasetArgsDict']] mongo_legacy_replicaset: MongoLegacyReplicaset is currently unstable, and its API may change, or it may be removed, without a major version bump.
         """
@@ -4126,9 +4116,6 @@ class Resource(pulumi.CustomResource):
     @_builtins.property
     @pulumi.getter(name="mcpGatewayOAuthDcr")
     def mcp_gateway_o_auth_dcr(self) -> pulumi.Output[Optional['outputs.ResourceMcpGatewayOAuthDcr']]:
-        """
-        MCPGatewayOAuthDCR is currently unstable, and its API may change, or it may be removed, without a major version bump.
-        """
         return pulumi.get(self, "mcp_gateway_o_auth_dcr")
 
     @_builtins.property


### PR DESCRIPTION
Update terraform-provider-sdm to v1.0.40-0.20260429101441-e76a4cb1e40b. Remove unstable-API deprecation notice from mcpGatewayOAuthDcr in schema. Regenerate all language SDKs.
