### PR TITLE
feat: bump terraform-provider-sdm and regenerate SDKs

### DIFF
--- a/provider/cmd/pulumi-resource-sdm/schema.json
+++ b/provider/cmd/pulumi-resource-sdm/schema.json
@@ -3486,6 +3486,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -3893,6 +3902,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -3962,6 +3980,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",
@@ -5688,6 +5715,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -5775,6 +5811,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -5860,6 +5905,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "tlsRequired": {
                     "type": "boolean",
@@ -6465,7 +6519,8 @@
             },
             "type": "object",
             "required": [
-                "name"
+                "name",
+                "url"
             ],
             "language": {
                 "nodejs": {
@@ -6473,7 +6528,8 @@
                         "bindInterface",
                         "name",
                         "portOverride",
-                        "subdomain"
+                        "subdomain",
+                        "url"
                     ]
                 }
             }
@@ -6603,6 +6659,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -6683,6 +6748,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",
@@ -6774,6 +6848,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -6848,6 +6931,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",
@@ -16126,6 +16218,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -16475,6 +16576,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -16531,6 +16641,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",
@@ -17976,6 +18095,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -18049,6 +18177,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "tlsRequired": {
                     "type": "boolean",
                     "description": "If set, TLS must be used to connect to this resource.\n"
@@ -18120,6 +18257,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "tlsRequired": {
                     "type": "boolean",
@@ -18749,6 +18895,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -18825,6 +18980,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",
@@ -18906,6 +19070,15 @@
                     },
                     "description": "Tags is a map of key, value pairs.\n"
                 },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
+                },
                 "url": {
                     "type": "string",
                     "description": "The URL to dial to initiate a connection from the egress node to this resource.\n* memcached:\n"
@@ -18970,6 +19143,15 @@
                         "type": "string"
                     },
                     "description": "Tags is a map of key, value pairs.\n"
+                },
+                "tlsCert": {
+                    "type": "string",
+                    "description": "Custom TLS certificate for upstream connection.\n",
+                    "secret": true
+                },
+                "tlsInsecure": {
+                    "type": "boolean",
+                    "description": "Skip TLS certificate verification for the upstream connection.\n"
                 },
                 "url": {
                     "type": "string",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.0
 	github.com/pulumi/pulumi/sdk/v3 v3.246.0
-	github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260529225225-2e458b57a93b
+	github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260701142713-bdbe593fb023
 )
 
 require (

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3974,8 +3974,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260529225225-2e458b57a93b h1:ZXV44Jc+MEs5SRMOAUtFWFMEC9mlHD8GL8iph+eVitw=
-github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260529225225-2e458b57a93b/go.mod h1:m8QrMKGiPFBN+KPYP6unLUG2lj7L8wvvuOn25tZn1vU=
+github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260701142713-bdbe593fb023 h1:aCJsQiI0bJ7a6BvCS5VKubwSdfU8/f9lYD9duE5spI8=
+github.com/strongdm/terraform-provider-sdm v1.0.40-0.20260701142713-bdbe593fb023/go.mod h1:m8QrMKGiPFBN+KPYP6unLUG2lj7L8wvvuOn25tZn1vU=
 github.com/substrait-io/substrait-go v0.4.2/go.mod h1:qhpnLmrcvAnlZsUyPXZRqldiHapPTXC3t7xFgDi3aQg=
 github.com/teekennedy/goldmark-markdown v0.3.0 h1:ik9/biVGCwGWFg8dQ3KVm2pQ/wiiG0whYiUcz9xH0W8=
 github.com/teekennedy/goldmark-markdown v0.3.0/go.mod h1:kMhDz8La77A9UHvJGsxejd0QUflN9sS+QXCqnhmxmNo=

--- a/sdk/dotnet/Inputs/ResourceClickHouseHttpArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceClickHouseHttpArgs.cs
@@ -83,6 +83,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceClickHouseHttpGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceClickHouseHttpGetArgs.cs
@@ -83,6 +83,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceCouchbaseDatabaseArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceCouchbaseDatabaseArgs.cs
@@ -101,6 +101,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceCouchbaseDatabaseGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceCouchbaseDatabaseGetArgs.cs
@@ -101,6 +101,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceCouchbaseWebUiArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceCouchbaseWebUiArgs.cs
@@ -83,6 +83,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceCouchbaseWebUiGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceCouchbaseWebUiGetArgs.cs
@@ -83,6 +83,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceHttpAuthArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpAuthArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceHttpAuthGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpAuthGetArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceHttpBasicAuthArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpBasicAuthArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceHttpBasicAuthGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpBasicAuthGetArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceHttpNoAuthArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpNoAuthArgs.cs
@@ -91,6 +91,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceHttpNoAuthGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceHttpNoAuthGetArgs.cs
@@ -91,6 +91,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>

--- a/sdk/dotnet/Inputs/ResourceLlmArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceLlmArgs.cs
@@ -93,8 +93,8 @@ namespace PiersKarsenbarg.Sdm.Inputs
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
-        [Input("url")]
-        public Input<string>? Url { get; set; }
+        [Input("url", required: true)]
+        public Input<string> Url { get; set; } = null!;
 
         public ResourceLlmArgs()
         {

--- a/sdk/dotnet/Inputs/ResourceLlmGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceLlmGetArgs.cs
@@ -93,8 +93,8 @@ namespace PiersKarsenbarg.Sdm.Inputs
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
-        [Input("url")]
-        public Input<string>? Url { get; set; }
+        [Input("url", required: true)]
+        public Input<string> Url { get; set; } = null!;
 
         public ResourceLlmGetArgs()
         {

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayNoAuthArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayNoAuthArgs.cs
@@ -73,6 +73,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayNoAuthGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayNoAuthGetArgs.cs
@@ -73,6 +73,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthDcrArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthDcrArgs.cs
@@ -97,6 +97,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthDcrGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthDcrGetArgs.cs
@@ -97,6 +97,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayOAuthGetArgs.cs
@@ -107,6 +107,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayPatArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayPatArgs.cs
@@ -89,6 +89,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Inputs/ResourceMcpGatewayPatGetArgs.cs
+++ b/sdk/dotnet/Inputs/ResourceMcpGatewayPatGetArgs.cs
@@ -89,6 +89,28 @@ namespace PiersKarsenbarg.Sdm.Inputs
             set => _tags = value;
         }
 
+        [Input("tlsCert")]
+        private Input<string>? _tlsCert;
+
+        /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public Input<string>? TlsCert
+        {
+            get => _tlsCert;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tlsCert = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        [Input("tlsInsecure")]
+        public Input<bool>? TlsInsecure { get; set; }
+
         /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:

--- a/sdk/dotnet/Outputs/GetResourceResourceClickHouseHttpResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceClickHouseHttpResult.cs
@@ -55,6 +55,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -86,6 +94,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url,
 
             string? username)
@@ -100,6 +112,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             ProxyClusterId = proxyClusterId;
             SecretStoreId = secretStoreId;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceCouchbaseDatabaseResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceCouchbaseDatabaseResult.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -103,6 +111,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string? username)
@@ -120,6 +132,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceCouchbaseWebUiResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceCouchbaseWebUiResult.cs
@@ -55,6 +55,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -86,6 +94,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url,
 
             string? username)
@@ -100,6 +112,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceHttpAuthResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceHttpAuthResult.cs
@@ -71,6 +71,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -110,6 +118,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string? url)
@@ -128,6 +140,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceHttpBasicAuthResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceHttpBasicAuthResult.cs
@@ -71,6 +71,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -114,6 +122,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string? url,
@@ -134,6 +146,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
             Username = username;

--- a/sdk/dotnet/Outputs/GetResourceResourceHttpNoAuthResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceHttpNoAuthResult.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -104,6 +112,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string? url)
@@ -121,6 +133,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayNoAuthResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayNoAuthResult.cs
@@ -55,6 +55,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -82,6 +90,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url)
         {
             BindInterface = bindInterface;
@@ -94,6 +106,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayOAuthDcrResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayOAuthDcrResult.cs
@@ -71,6 +71,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -106,6 +114,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url)
         {
             BindInterface = bindInterface;
@@ -122,6 +134,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayOAuthResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayOAuthResult.cs
@@ -71,6 +71,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -110,6 +118,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url,
 
             string? username)
@@ -128,6 +140,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayPatResult.cs
+++ b/sdk/dotnet/Outputs/GetResourceResourceMcpGatewayPatResult.cs
@@ -59,6 +59,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -88,6 +96,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string? url)
         {
             BindInterface = bindInterface;
@@ -101,6 +113,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/dotnet/Outputs/ResourceClickHouseHttp.cs
+++ b/sdk/dotnet/Outputs/ResourceClickHouseHttp.cs
@@ -51,6 +51,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -80,6 +88,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url,
 
             string? username)
@@ -93,6 +105,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             ProxyClusterId = proxyClusterId;
             SecretStoreId = secretStoreId;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/ResourceCouchbaseDatabase.cs
+++ b/sdk/dotnet/Outputs/ResourceCouchbaseDatabase.cs
@@ -63,6 +63,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -97,6 +105,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string? username)
@@ -113,6 +125,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/ResourceCouchbaseWebUi.cs
+++ b/sdk/dotnet/Outputs/ResourceCouchbaseWebUi.cs
@@ -51,6 +51,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -80,6 +88,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url,
 
             string? username)
@@ -93,6 +105,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/ResourceHttpAuth.cs
+++ b/sdk/dotnet/Outputs/ResourceHttpAuth.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -104,6 +112,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string url)
@@ -121,6 +133,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
         }

--- a/sdk/dotnet/Outputs/ResourceHttpBasicAuth.cs
+++ b/sdk/dotnet/Outputs/ResourceHttpBasicAuth.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -108,6 +116,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string url,
@@ -127,6 +139,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
             Username = username;

--- a/sdk/dotnet/Outputs/ResourceHttpNoAuth.cs
+++ b/sdk/dotnet/Outputs/ResourceHttpNoAuth.cs
@@ -63,6 +63,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// If set, TLS must be used to connect to this resource.
         /// </summary>
         public readonly bool? TlsRequired;
@@ -98,6 +106,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             bool? tlsRequired,
 
             string url)
@@ -114,6 +126,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             TlsRequired = tlsRequired;
             Url = url;
         }

--- a/sdk/dotnet/Outputs/ResourceLlm.cs
+++ b/sdk/dotnet/Outputs/ResourceLlm.cs
@@ -58,7 +58,7 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
-        public readonly string? Url;
+        public readonly string Url;
 
         [OutputConstructor]
         private ResourceLlm(
@@ -82,7 +82,7 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
-            string? url)
+            string url)
         {
             BindInterface = bindInterface;
             EgressFilter = egressFilter;

--- a/sdk/dotnet/Outputs/ResourceMcpGatewayNoAuth.cs
+++ b/sdk/dotnet/Outputs/ResourceMcpGatewayNoAuth.cs
@@ -51,6 +51,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -76,6 +84,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url)
         {
             BindInterface = bindInterface;
@@ -87,6 +99,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/dotnet/Outputs/ResourceMcpGatewayOAuth.cs
+++ b/sdk/dotnet/Outputs/ResourceMcpGatewayOAuth.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -104,6 +112,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url,
 
             string username)
@@ -121,6 +133,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
             Username = username;
         }

--- a/sdk/dotnet/Outputs/ResourceMcpGatewayOAuthDcr.cs
+++ b/sdk/dotnet/Outputs/ResourceMcpGatewayOAuthDcr.cs
@@ -67,6 +67,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -100,6 +108,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url)
         {
             BindInterface = bindInterface;
@@ -115,6 +127,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/dotnet/Outputs/ResourceMcpGatewayPat.cs
+++ b/sdk/dotnet/Outputs/ResourceMcpGatewayPat.cs
@@ -55,6 +55,14 @@ namespace PiersKarsenbarg.Sdm.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Tags;
         /// <summary>
+        /// Custom TLS certificate for upstream connection.
+        /// </summary>
+        public readonly string? TlsCert;
+        /// <summary>
+        /// Skip TLS certificate verification for the upstream connection.
+        /// </summary>
+        public readonly bool? TlsInsecure;
+        /// <summary>
         /// The URL to dial to initiate a connection from the egress node to this resource.
         /// * memcached:
         /// </summary>
@@ -82,6 +90,10 @@ namespace PiersKarsenbarg.Sdm.Outputs
 
             ImmutableDictionary<string, string>? tags,
 
+            string? tlsCert,
+
+            bool? tlsInsecure,
+
             string url)
         {
             BindInterface = bindInterface;
@@ -94,6 +106,8 @@ namespace PiersKarsenbarg.Sdm.Outputs
             SecretStoreId = secretStoreId;
             Subdomain = subdomain;
             Tags = tags;
+            TlsCert = tlsCert;
+            TlsInsecure = tlsInsecure;
             Url = url;
         }
     }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -2523,6 +2523,14 @@ export interface ResourceClickHouseHttp {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -2823,6 +2831,14 @@ export interface ResourceCouchbaseDatabase {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: pulumi.Input<boolean | undefined>;
@@ -2869,6 +2885,14 @@ export interface ResourceCouchbaseWebUi {
      * Tags is a map of key, value pairs.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -4104,6 +4128,14 @@ export interface ResourceHttpAuth {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: pulumi.Input<boolean | undefined>;
@@ -4168,6 +4200,14 @@ export interface ResourceHttpBasicAuth {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: pulumi.Input<boolean | undefined>;
@@ -4231,6 +4271,14 @@ export interface ResourceHttpNoAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
     /**
      * If set, TLS must be used to connect to this resource.
      */
@@ -4667,7 +4715,7 @@ export interface ResourceLlm {
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
-    url?: pulumi.Input<string | undefined>;
+    url: pulumi.Input<string>;
 }
 
 export interface ResourceMaria {
@@ -4771,6 +4819,14 @@ export interface ResourceMcpGatewayNoAuth {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -4830,6 +4886,14 @@ export interface ResourceMcpGatewayOAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -4895,6 +4959,14 @@ export interface ResourceMcpGatewayOAuthDcr {
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -4942,6 +5014,14 @@ export interface ResourceMcpGatewayPat {
      * Tags is a map of key, value pairs.
      */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: pulumi.Input<string | undefined>;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: pulumi.Input<boolean | undefined>;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -3361,6 +3361,14 @@ export interface GetResourceResourceClickHouseHttp {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -3681,6 +3689,14 @@ export interface GetResourceResourceCouchbaseDatabase {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -3731,6 +3747,14 @@ export interface GetResourceResourceCouchbaseWebUi {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -5054,6 +5078,14 @@ export interface GetResourceResourceHttpAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -5122,6 +5154,14 @@ export interface GetResourceResourceHttpBasicAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -5189,6 +5229,14 @@ export interface GetResourceResourceHttpNoAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * If set, TLS must be used to connect to this resource.
      */
@@ -5765,6 +5813,14 @@ export interface GetResourceResourceMcpGatewayNoAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -5828,6 +5884,14 @@ export interface GetResourceResourceMcpGatewayOAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -5897,6 +5961,14 @@ export interface GetResourceResourceMcpGatewayOAuthDcr {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -5948,6 +6020,14 @@ export interface GetResourceResourceMcpGatewayPat {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -12155,6 +12235,14 @@ export interface ResourceClickHouseHttp {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -12455,6 +12543,14 @@ export interface ResourceCouchbaseDatabase {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -12501,6 +12597,14 @@ export interface ResourceCouchbaseWebUi {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -13736,6 +13840,14 @@ export interface ResourceHttpAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -13800,6 +13912,14 @@ export interface ResourceHttpBasicAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * If set, TLS must be used to connect to this resource.
      */
     tlsRequired?: boolean;
@@ -13863,6 +13983,14 @@ export interface ResourceHttpNoAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * If set, TLS must be used to connect to this resource.
      */
@@ -14299,7 +14427,7 @@ export interface ResourceLlm {
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
-    url?: string;
+    url: string;
 }
 
 export interface ResourceMaria {
@@ -14403,6 +14531,14 @@ export interface ResourceMcpGatewayNoAuth {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -14462,6 +14598,14 @@ export interface ResourceMcpGatewayOAuth {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
@@ -14527,6 +14671,14 @@ export interface ResourceMcpGatewayOAuthDcr {
      */
     tags?: {[key: string]: string};
     /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
+    /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:
      */
@@ -14574,6 +14726,14 @@ export interface ResourceMcpGatewayPat {
      * Tags is a map of key, value pairs.
      */
     tags?: {[key: string]: string};
+    /**
+     * Custom TLS certificate for upstream connection.
+     */
+    tlsCert?: string;
+    /**
+     * Skip TLS certificate verification for the upstream connection.
+     */
+    tlsInsecure?: boolean;
     /**
      * The URL to dial to initiate a connection from the egress node to this resource.
      * * memcached:

--- a/sdk/python/pierskarsenbarg_pulumi_sdm/_inputs.py
+++ b/sdk/python/pierskarsenbarg_pulumi_sdm/_inputs.py
@@ -12099,6 +12099,14 @@ class ResourceClickHouseHttpArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The username to authenticate with.
@@ -12117,6 +12125,8 @@ class ResourceClickHouseHttpArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  username: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
@@ -12130,6 +12140,8 @@ class ResourceClickHouseHttpArgs:
         :param pulumi.Input[_builtins.str] proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.str] username: The username to authenticate with.
         """
         pulumi.set(__self__, "name", name)
@@ -12150,6 +12162,10 @@ class ResourceClickHouseHttpArgs:
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if username is not None:
             pulumi.set(__self__, "username", username)
 
@@ -12273,6 +12289,30 @@ class ResourceClickHouseHttpArgs:
     @tags.setter
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
 
     @_builtins.property
     @pulumi.getter
@@ -13502,6 +13542,14 @@ class ResourceCouchbaseDatabaseArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     tls_required: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     If set, TLS must be used to connect to this resource.
@@ -13526,6 +13574,8 @@ class ResourceCouchbaseDatabaseArgs:
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  tls_required: pulumi.Input[Optional[_builtins.bool]] = None,
                  username: pulumi.Input[Optional[_builtins.str]] = None):
         """
@@ -13541,6 +13591,8 @@ class ResourceCouchbaseDatabaseArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.bool] tls_required: If set, TLS must be used to connect to this resource.
         :param pulumi.Input[_builtins.str] username: The username to authenticate with.
         """
@@ -13565,6 +13617,10 @@ class ResourceCouchbaseDatabaseArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if username is not None:
@@ -13715,6 +13771,30 @@ class ResourceCouchbaseDatabaseArgs:
         pulumi.set(self, "tags", value)
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
@@ -13781,6 +13861,14 @@ class ResourceCouchbaseWebUiArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The username to authenticate with.
@@ -13799,6 +13887,8 @@ class ResourceCouchbaseWebUiArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  username: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
@@ -13812,6 +13902,8 @@ class ResourceCouchbaseWebUiArgs:
         :param pulumi.Input[_builtins.str] proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.str] username: The username to authenticate with.
         """
         pulumi.set(__self__, "name", name)
@@ -13831,6 +13923,10 @@ class ResourceCouchbaseWebUiArgs:
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if username is not None:
             pulumi.set(__self__, "username", username)
 
@@ -13954,6 +14050,30 @@ class ResourceCouchbaseWebUiArgs:
     @tags.setter
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
 
     @_builtins.property
     @pulumi.getter
@@ -19683,6 +19803,14 @@ class ResourceHttpAuthArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     tls_required: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     If set, TLS must be used to connect to this resource.
@@ -19705,6 +19833,8 @@ class ResourceHttpAuthArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  tls_required: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] healthcheck_path: This path will be used to check the health of your site.
@@ -19722,6 +19852,8 @@ class ResourceHttpAuthArgs:
         :param pulumi.Input[_builtins.str] proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.bool] tls_required: If set, TLS must be used to connect to this resource.
         """
         pulumi.set(__self__, "healthcheck_path", healthcheck_path)
@@ -19748,6 +19880,10 @@ class ResourceHttpAuthArgs:
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
 
@@ -19921,6 +20057,30 @@ class ResourceHttpAuthArgs:
         pulumi.set(self, "tags", value)
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
@@ -19991,6 +20151,14 @@ class ResourceHttpBasicAuthArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     tls_required: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     If set, TLS must be used to connect to this resource.
@@ -20017,6 +20185,8 @@ class ResourceHttpBasicAuthArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  tls_required: pulumi.Input[Optional[_builtins.bool]] = None,
                  username: pulumi.Input[Optional[_builtins.str]] = None):
         """
@@ -20035,6 +20205,8 @@ class ResourceHttpBasicAuthArgs:
         :param pulumi.Input[_builtins.str] proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.bool] tls_required: If set, TLS must be used to connect to this resource.
         :param pulumi.Input[_builtins.str] username: The username to authenticate with.
         """
@@ -20062,6 +20234,10 @@ class ResourceHttpBasicAuthArgs:
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if username is not None:
@@ -20237,6 +20413,30 @@ class ResourceHttpBasicAuthArgs:
         pulumi.set(self, "tags", value)
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
@@ -20315,6 +20515,14 @@ class ResourceHttpNoAuthArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
     tls_required: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     If set, TLS must be used to connect to this resource.
@@ -20336,6 +20544,8 @@ class ResourceHttpNoAuthArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None,
                  tls_required: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] healthcheck_path: This path will be used to check the health of your site.
@@ -20352,6 +20562,8 @@ class ResourceHttpNoAuthArgs:
         :param pulumi.Input[_builtins.str] proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param pulumi.Input[_builtins.bool] tls_required: If set, TLS must be used to connect to this resource.
         """
         pulumi.set(__self__, "healthcheck_path", healthcheck_path)
@@ -20376,6 +20588,10 @@ class ResourceHttpNoAuthArgs:
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
 
@@ -20535,6 +20751,30 @@ class ResourceHttpNoAuthArgs:
     @tags.setter
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
 
     @_builtins.property
     @pulumi.getter(name="tlsRequired")
@@ -22398,6 +22638,11 @@ class ResourceLlmArgsDict(TypedDict):
     """
     Unique human-readable name of the Resource.
     """
+    url: pulumi.Input[_builtins.str]
+    """
+    The URL to dial to initiate a connection from the egress node to this resource.
+    * memcached:
+    """
     bind_interface: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The bind interface is the IP address to which the port override of a resource is bound (for example, 127.0.0.1). It is automatically generated if not provided and may also be set to one of the ResourceIPAllocationMode constants to select between VNM, loopback, or default allocation.
@@ -22434,16 +22679,12 @@ class ResourceLlmArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
-    url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
-    """
-    The URL to dial to initiate a connection from the egress node to this resource.
-    * memcached:
-    """
 
 @pulumi.input_type
 class ResourceLlmArgs:
     def __init__(__self__, *,
                  name: pulumi.Input[_builtins.str],
+                 url: pulumi.Input[_builtins.str],
                  bind_interface: pulumi.Input[Optional[_builtins.str]] = None,
                  egress_filter: pulumi.Input[Optional[_builtins.str]] = None,
                  models: pulumi.Input[Optional[_builtins.str]] = None,
@@ -22452,10 +22693,11 @@ class ResourceLlmArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
-                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
-                 url: pulumi.Input[Optional[_builtins.str]] = None):
+                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
+        :param pulumi.Input[_builtins.str] url: The URL to dial to initiate a connection from the egress node to this resource.
+               * memcached:
         :param pulumi.Input[_builtins.str] bind_interface: The bind interface is the IP address to which the port override of a resource is bound (for example, 127.0.0.1). It is automatically generated if not provided and may also be set to one of the ResourceIPAllocationMode constants to select between VNM, loopback, or default allocation.
         :param pulumi.Input[_builtins.str] egress_filter: A filter applied to the routing logic to pin datasource to nodes.
         :param pulumi.Input[_builtins.str] models: Space-separated list of model names this resource accepts. Requests for unlisted models are rejected. Leave empty to allow all models.
@@ -22465,10 +22707,9 @@ class ResourceLlmArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
-        :param pulumi.Input[_builtins.str] url: The URL to dial to initiate a connection from the egress node to this resource.
-               * memcached:
         """
         pulumi.set(__self__, "name", name)
+        pulumi.set(__self__, "url", url)
         if bind_interface is not None:
             pulumi.set(__self__, "bind_interface", bind_interface)
         if egress_filter is not None:
@@ -22487,8 +22728,6 @@ class ResourceLlmArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-        if url is not None:
-            pulumi.set(__self__, "url", url)
 
     @_builtins.property
     @pulumi.getter
@@ -22501,6 +22740,19 @@ class ResourceLlmArgs:
     @name.setter
     def name(self, value: pulumi.Input[_builtins.str]):
         pulumi.set(self, "name", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def url(self) -> pulumi.Input[_builtins.str]:
+        """
+        The URL to dial to initiate a connection from the egress node to this resource.
+        * memcached:
+        """
+        return pulumi.get(self, "url")
+
+    @url.setter
+    def url(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "url", value)
 
     @_builtins.property
     @pulumi.getter(name="bindInterface")
@@ -22609,19 +22861,6 @@ class ResourceLlmArgs:
     @tags.setter
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
-
-    @_builtins.property
-    @pulumi.getter
-    def url(self) -> pulumi.Input[Optional[_builtins.str]]:
-        """
-        The URL to dial to initiate a connection from the egress node to this resource.
-        * memcached:
-        """
-        return pulumi.get(self, "url")
-
-    @url.setter
-    def url(self, value: pulumi.Input[Optional[_builtins.str]]):
-        pulumi.set(self, "url", value)
 
 
 class ResourceMariaArgsDict(TypedDict):
@@ -22973,6 +23212,14 @@ class ResourceMcpGatewayNoAuthArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
 
 @pulumi.input_type
 class ResourceMcpGatewayNoAuthArgs:
@@ -22986,7 +23233,9 @@ class ResourceMcpGatewayNoAuthArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
-                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
+                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
         :param pulumi.Input[_builtins.str] url: The URL to dial to initiate a connection from the egress node to this resource.
@@ -22999,6 +23248,8 @@ class ResourceMcpGatewayNoAuthArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "url", url)
@@ -23018,6 +23269,10 @@ class ResourceMcpGatewayNoAuthArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -23140,6 +23395,30 @@ class ResourceMcpGatewayNoAuthArgs:
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
 
 class ResourceMcpGatewayOAuthArgsDict(TypedDict):
     name: pulumi.Input[_builtins.str]
@@ -23203,6 +23482,14 @@ class ResourceMcpGatewayOAuthArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
 
 @pulumi.input_type
 class ResourceMcpGatewayOAuthArgs:
@@ -23221,7 +23508,9 @@ class ResourceMcpGatewayOAuthArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
-                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
+                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
         :param pulumi.Input[_builtins.str] oauth_auth_endpoint: The OAuth 2.0 authorization endpoint URL.
@@ -23239,6 +23528,8 @@ class ResourceMcpGatewayOAuthArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "oauth_auth_endpoint", oauth_auth_endpoint)
@@ -23265,6 +23556,10 @@ class ResourceMcpGatewayOAuthArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -23447,6 +23742,30 @@ class ResourceMcpGatewayOAuthArgs:
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
 
 class ResourceMcpGatewayOAuthDcrArgsDict(TypedDict):
     name: pulumi.Input[_builtins.str]
@@ -23506,6 +23825,14 @@ class ResourceMcpGatewayOAuthDcrArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
 
 @pulumi.input_type
 class ResourceMcpGatewayOAuthDcrArgs:
@@ -23523,7 +23850,9 @@ class ResourceMcpGatewayOAuthDcrArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
-                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
+                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
         :param pulumi.Input[_builtins.str] oauth_auth_endpoint: The OAuth 2.0 authorization endpoint URL.
@@ -23540,6 +23869,8 @@ class ResourceMcpGatewayOAuthDcrArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "oauth_auth_endpoint", oauth_auth_endpoint)
@@ -23564,6 +23895,10 @@ class ResourceMcpGatewayOAuthDcrArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -23734,6 +24069,30 @@ class ResourceMcpGatewayOAuthDcrArgs:
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
+
 
 class ResourceMcpGatewayPatArgsDict(TypedDict):
     name: pulumi.Input[_builtins.str]
@@ -23781,6 +24140,14 @@ class ResourceMcpGatewayPatArgsDict(TypedDict):
     """
     Tags is a map of key, value pairs.
     """
+    tls_cert: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    """
+    Custom TLS certificate for upstream connection.
+    """
+    tls_insecure: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    """
+    Skip TLS certificate verification for the upstream connection.
+    """
 
 @pulumi.input_type
 class ResourceMcpGatewayPatArgs:
@@ -23795,7 +24162,9 @@ class ResourceMcpGatewayPatArgs:
                  proxy_cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
                  secret_store_id: pulumi.Input[Optional[_builtins.str]] = None,
                  subdomain: pulumi.Input[Optional[_builtins.str]] = None,
-                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
+                 tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
+                 tls_cert: pulumi.Input[Optional[_builtins.str]] = None,
+                 tls_insecure: pulumi.Input[Optional[_builtins.bool]] = None):
         """
         :param pulumi.Input[_builtins.str] name: Unique human-readable name of the Resource.
         :param pulumi.Input[_builtins.str] url: The URL to dial to initiate a connection from the egress node to this resource.
@@ -23809,6 +24178,8 @@ class ResourceMcpGatewayPatArgs:
         :param pulumi.Input[_builtins.str] secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param pulumi.Input[_builtins.str] subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags is a map of key, value pairs.
+        :param pulumi.Input[_builtins.str] tls_cert: Custom TLS certificate for upstream connection.
+        :param pulumi.Input[_builtins.bool] tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "url", url)
@@ -23830,6 +24201,10 @@ class ResourceMcpGatewayPatArgs:
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -23963,6 +24338,30 @@ class ResourceMcpGatewayPatArgs:
     @tags.setter
     def tags(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "tags", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> pulumi.Input[Optional[_builtins.str]]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @tls_cert.setter
+    def tls_cert(self, value: pulumi.Input[Optional[_builtins.str]]):
+        pulumi.set(self, "tls_cert", value)
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @tls_insecure.setter
+    def tls_insecure(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "tls_insecure", value)
 
 
 class ResourceMemcachedArgsDict(TypedDict):

--- a/sdk/python/pierskarsenbarg_pulumi_sdm/outputs.py
+++ b/sdk/python/pierskarsenbarg_pulumi_sdm/outputs.py
@@ -8798,6 +8798,10 @@ class ResourceClickHouseHttp(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceClickHouseHttp. Access the value via the '{suggest}' property getter instead.")
@@ -8821,6 +8825,8 @@ class ResourceClickHouseHttp(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  username: Optional[_builtins.str] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
@@ -8834,6 +8840,8 @@ class ResourceClickHouseHttp(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str username: The username to authenticate with.
         """
         pulumi.set(__self__, "name", name)
@@ -8854,6 +8862,10 @@ class ResourceClickHouseHttp(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if username is not None:
             pulumi.set(__self__, "username", username)
 
@@ -8937,6 +8949,22 @@ class ResourceClickHouseHttp(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter
@@ -9776,6 +9804,10 @@ class ResourceCouchbaseDatabase(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
         elif key == "tlsRequired":
             suggest = "tls_required"
 
@@ -9803,6 +9835,8 @@ class ResourceCouchbaseDatabase(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -9818,6 +9852,8 @@ class ResourceCouchbaseDatabase(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str username: The username to authenticate with.
         """
@@ -9842,6 +9878,10 @@ class ResourceCouchbaseDatabase(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if username is not None:
@@ -9944,6 +9984,22 @@ class ResourceCouchbaseDatabase(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -9975,6 +10031,10 @@ class ResourceCouchbaseWebUi(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceCouchbaseWebUi. Access the value via the '{suggest}' property getter instead.")
@@ -9998,6 +10058,8 @@ class ResourceCouchbaseWebUi(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  username: Optional[_builtins.str] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
@@ -10011,6 +10073,8 @@ class ResourceCouchbaseWebUi(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str username: The username to authenticate with.
         """
         pulumi.set(__self__, "name", name)
@@ -10030,6 +10094,10 @@ class ResourceCouchbaseWebUi(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if username is not None:
             pulumi.set(__self__, "username", username)
 
@@ -10113,6 +10181,22 @@ class ResourceCouchbaseWebUi(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter
@@ -14177,6 +14261,10 @@ class ResourceHttpAuth(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
         elif key == "tlsRequired":
             suggest = "tls_required"
 
@@ -14206,6 +14294,8 @@ class ResourceHttpAuth(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None):
         """
         :param _builtins.str healthcheck_path: This path will be used to check the health of your site.
@@ -14223,6 +14313,8 @@ class ResourceHttpAuth(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         """
         pulumi.set(__self__, "healthcheck_path", healthcheck_path)
@@ -14249,6 +14341,10 @@ class ResourceHttpAuth(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
 
@@ -14366,6 +14462,22 @@ class ResourceHttpAuth(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -14397,6 +14509,10 @@ class ResourceHttpBasicAuth(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
         elif key == "tlsRequired":
             suggest = "tls_required"
 
@@ -14426,6 +14542,8 @@ class ResourceHttpBasicAuth(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -14444,6 +14562,8 @@ class ResourceHttpBasicAuth(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str username: The username to authenticate with.
         """
@@ -14471,6 +14591,10 @@ class ResourceHttpBasicAuth(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if username is not None:
@@ -14590,6 +14714,22 @@ class ResourceHttpBasicAuth(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -14629,6 +14769,10 @@ class ResourceHttpNoAuth(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
         elif key == "tlsRequired":
             suggest = "tls_required"
 
@@ -14657,6 +14801,8 @@ class ResourceHttpNoAuth(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None):
         """
         :param _builtins.str healthcheck_path: This path will be used to check the health of your site.
@@ -14673,6 +14819,8 @@ class ResourceHttpNoAuth(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         """
         pulumi.set(__self__, "healthcheck_path", healthcheck_path)
@@ -14697,6 +14845,10 @@ class ResourceHttpNoAuth(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
 
@@ -14804,6 +14956,22 @@ class ResourceHttpNoAuth(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter(name="tlsRequired")
@@ -16159,6 +16327,7 @@ class ResourceLlm(dict):
 
     def __init__(__self__, *,
                  name: _builtins.str,
+                 url: _builtins.str,
                  bind_interface: Optional[_builtins.str] = None,
                  egress_filter: Optional[_builtins.str] = None,
                  models: Optional[_builtins.str] = None,
@@ -16167,10 +16336,11 @@ class ResourceLlm(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
-                 tags: Optional[Mapping[str, _builtins.str]] = None,
-                 url: Optional[_builtins.str] = None):
+                 tags: Optional[Mapping[str, _builtins.str]] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
+        :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
+               * memcached:
         :param _builtins.str bind_interface: The bind interface is the IP address to which the port override of a resource is bound (for example, 127.0.0.1). It is automatically generated if not provided and may also be set to one of the ResourceIPAllocationMode constants to select between VNM, loopback, or default allocation.
         :param _builtins.str egress_filter: A filter applied to the routing logic to pin datasource to nodes.
         :param _builtins.str models: Space-separated list of model names this resource accepts. Requests for unlisted models are rejected. Leave empty to allow all models.
@@ -16180,10 +16350,9 @@ class ResourceLlm(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
-        :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
-               * memcached:
         """
         pulumi.set(__self__, "name", name)
+        pulumi.set(__self__, "url", url)
         if bind_interface is not None:
             pulumi.set(__self__, "bind_interface", bind_interface)
         if egress_filter is not None:
@@ -16202,8 +16371,6 @@ class ResourceLlm(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-        if url is not None:
-            pulumi.set(__self__, "url", url)
 
     @_builtins.property
     @pulumi.getter
@@ -16212,6 +16379,15 @@ class ResourceLlm(dict):
         Unique human-readable name of the Resource.
         """
         return pulumi.get(self, "name")
+
+    @_builtins.property
+    @pulumi.getter
+    def url(self) -> _builtins.str:
+        """
+        The URL to dial to initiate a connection from the egress node to this resource.
+        * memcached:
+        """
+        return pulumi.get(self, "url")
 
     @_builtins.property
     @pulumi.getter(name="bindInterface")
@@ -16284,15 +16460,6 @@ class ResourceLlm(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
-
-    @_builtins.property
-    @pulumi.getter
-    def url(self) -> Optional[_builtins.str]:
-        """
-        The URL to dial to initiate a connection from the egress node to this resource.
-        * memcached:
-        """
-        return pulumi.get(self, "url")
 
 
 @pulumi.output_type
@@ -16524,6 +16691,10 @@ class ResourceMcpGatewayNoAuth(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceMcpGatewayNoAuth. Access the value via the '{suggest}' property getter instead.")
@@ -16546,7 +16717,9 @@ class ResourceMcpGatewayNoAuth(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
-                 tags: Optional[Mapping[str, _builtins.str]] = None):
+                 tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
@@ -16559,6 +16732,8 @@ class ResourceMcpGatewayNoAuth(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "url", url)
@@ -16578,6 +16753,10 @@ class ResourceMcpGatewayNoAuth(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -16660,6 +16839,22 @@ class ResourceMcpGatewayNoAuth(dict):
         """
         return pulumi.get(self, "tags")
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
 
 @pulumi.output_type
 class ResourceMcpGatewayOAuth(dict):
@@ -16682,6 +16877,10 @@ class ResourceMcpGatewayOAuth(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceMcpGatewayOAuth. Access the value via the '{suggest}' property getter instead.")
@@ -16709,7 +16908,9 @@ class ResourceMcpGatewayOAuth(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
-                 tags: Optional[Mapping[str, _builtins.str]] = None):
+                 tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
         :param _builtins.str oauth_auth_endpoint: The OAuth 2.0 authorization endpoint URL.
@@ -16727,6 +16928,8 @@ class ResourceMcpGatewayOAuth(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "oauth_auth_endpoint", oauth_auth_endpoint)
@@ -16753,6 +16956,10 @@ class ResourceMcpGatewayOAuth(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -16875,6 +17082,22 @@ class ResourceMcpGatewayOAuth(dict):
         """
         return pulumi.get(self, "tags")
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
 
 @pulumi.output_type
 class ResourceMcpGatewayOAuthDcr(dict):
@@ -16899,6 +17122,10 @@ class ResourceMcpGatewayOAuthDcr(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceMcpGatewayOAuthDcr. Access the value via the '{suggest}' property getter instead.")
@@ -16925,7 +17152,9 @@ class ResourceMcpGatewayOAuthDcr(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
-                 tags: Optional[Mapping[str, _builtins.str]] = None):
+                 tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
         :param _builtins.str oauth_auth_endpoint: The OAuth 2.0 authorization endpoint URL.
@@ -16942,6 +17171,8 @@ class ResourceMcpGatewayOAuthDcr(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "oauth_auth_endpoint", oauth_auth_endpoint)
@@ -16966,6 +17197,10 @@ class ResourceMcpGatewayOAuthDcr(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -17080,6 +17315,22 @@ class ResourceMcpGatewayOAuthDcr(dict):
         """
         return pulumi.get(self, "tags")
 
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
 
 @pulumi.output_type
 class ResourceMcpGatewayPat(dict):
@@ -17096,6 +17347,10 @@ class ResourceMcpGatewayPat(dict):
             suggest = "proxy_cluster_id"
         elif key == "secretStoreId":
             suggest = "secret_store_id"
+        elif key == "tlsCert":
+            suggest = "tls_cert"
+        elif key == "tlsInsecure":
+            suggest = "tls_insecure"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in ResourceMcpGatewayPat. Access the value via the '{suggest}' property getter instead.")
@@ -17119,7 +17374,9 @@ class ResourceMcpGatewayPat(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
-                 tags: Optional[Mapping[str, _builtins.str]] = None):
+                 tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None):
         """
         :param _builtins.str name: Unique human-readable name of the Resource.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
@@ -17133,6 +17390,8 @@ class ResourceMcpGatewayPat(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "url", url)
@@ -17154,6 +17413,10 @@ class ResourceMcpGatewayPat(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
 
     @_builtins.property
     @pulumi.getter
@@ -17243,6 +17506,22 @@ class ResourceMcpGatewayPat(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
 
 @pulumi.output_type
@@ -38973,6 +39252,8 @@ class GetResourceResourceClickHouseHttpResult(dict):
                  proxy_cluster_id: Optional[_builtins.str] = None,
                  secret_store_id: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -38986,6 +39267,8 @@ class GetResourceResourceClickHouseHttpResult(dict):
         :param _builtins.str proxy_cluster_id: ID of the proxy cluster for this resource, if any.
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         :param _builtins.str username: The username to authenticate with.
@@ -39010,6 +39293,10 @@ class GetResourceResourceClickHouseHttpResult(dict):
             pulumi.set(__self__, "secret_store_id", secret_store_id)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
         if username is not None:
@@ -39094,6 +39381,22 @@ class GetResourceResourceClickHouseHttpResult(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter
@@ -39889,6 +40192,8 @@ class GetResourceResourceCouchbaseDatabaseResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -39905,6 +40210,8 @@ class GetResourceResourceCouchbaseDatabaseResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str username: The username to authenticate with.
         """
@@ -39934,6 +40241,10 @@ class GetResourceResourceCouchbaseDatabaseResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if username is not None:
@@ -40044,6 +40355,22 @@ class GetResourceResourceCouchbaseDatabaseResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -40073,6 +40400,8 @@ class GetResourceResourceCouchbaseWebUiResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -40086,6 +40415,8 @@ class GetResourceResourceCouchbaseWebUiResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         :param _builtins.str username: The username to authenticate with.
@@ -40110,6 +40441,10 @@ class GetResourceResourceCouchbaseWebUiResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
         if username is not None:
@@ -40194,6 +40529,22 @@ class GetResourceResourceCouchbaseWebUiResult(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter
@@ -43947,6 +44298,8 @@ class GetResourceResourceHttpAuthResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None):
         """
@@ -43964,6 +44317,8 @@ class GetResourceResourceHttpAuthResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
@@ -43996,6 +44351,10 @@ class GetResourceResourceHttpAuthResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if url is not None:
@@ -44114,6 +44473,22 @@ class GetResourceResourceHttpAuthResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -44148,6 +44523,8 @@ class GetResourceResourceHttpBasicAuthResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None,
                  username: Optional[_builtins.str] = None):
@@ -44166,6 +44543,8 @@ class GetResourceResourceHttpBasicAuthResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
@@ -44199,6 +44578,10 @@ class GetResourceResourceHttpBasicAuthResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if url is not None:
@@ -44319,6 +44702,22 @@ class GetResourceResourceHttpBasicAuthResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter(name="tlsRequired")
     def tls_required(self) -> Optional[_builtins.bool]:
         """
@@ -44360,6 +44759,8 @@ class GetResourceResourceHttpNoAuthResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  tls_required: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None):
         """
@@ -44376,6 +44777,8 @@ class GetResourceResourceHttpNoAuthResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.bool tls_required: If set, TLS must be used to connect to this resource.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
@@ -44406,6 +44809,10 @@ class GetResourceResourceHttpNoAuthResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if tls_required is not None:
             pulumi.set(__self__, "tls_required", tls_required)
         if url is not None:
@@ -44514,6 +44921,22 @@ class GetResourceResourceHttpNoAuthResult(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter(name="tlsRequired")
@@ -46096,6 +46519,8 @@ class GetResourceResourceMcpGatewayNoAuthResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None):
         """
         :param _builtins.str hostname: The host to dial to initiate a connection from the egress node to this resource.
@@ -46108,6 +46533,8 @@ class GetResourceResourceMcpGatewayNoAuthResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         """
@@ -46130,6 +46557,10 @@ class GetResourceResourceMcpGatewayNoAuthResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
 
@@ -46214,6 +46645,22 @@ class GetResourceResourceMcpGatewayNoAuthResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter
     def url(self) -> Optional[_builtins.str]:
         """
@@ -46240,6 +46687,8 @@ class GetResourceResourceMcpGatewayOAuthResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None,
                  username: Optional[_builtins.str] = None):
         """
@@ -46257,6 +46706,8 @@ class GetResourceResourceMcpGatewayOAuthResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         :param _builtins.str username: The username to authenticate with.
@@ -46288,6 +46739,10 @@ class GetResourceResourceMcpGatewayOAuthResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
         if username is not None:
@@ -46406,6 +46861,22 @@ class GetResourceResourceMcpGatewayOAuthResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter
     def url(self) -> Optional[_builtins.str]:
         """
@@ -46440,6 +46911,8 @@ class GetResourceResourceMcpGatewayOAuthDcrResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None):
         """
         :param _builtins.str hostname: The host to dial to initiate a connection from the egress node to this resource.
@@ -46456,6 +46929,8 @@ class GetResourceResourceMcpGatewayOAuthDcrResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         """
@@ -46486,6 +46961,10 @@ class GetResourceResourceMcpGatewayOAuthDcrResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
 
@@ -46602,6 +47081,22 @@ class GetResourceResourceMcpGatewayOAuthDcrResult(dict):
         return pulumi.get(self, "tags")
 
     @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
+
+    @_builtins.property
     @pulumi.getter
     def url(self) -> Optional[_builtins.str]:
         """
@@ -46625,6 +47120,8 @@ class GetResourceResourceMcpGatewayPatResult(dict):
                  secret_store_id: Optional[_builtins.str] = None,
                  subdomain: Optional[_builtins.str] = None,
                  tags: Optional[Mapping[str, _builtins.str]] = None,
+                 tls_cert: Optional[_builtins.str] = None,
+                 tls_insecure: Optional[_builtins.bool] = None,
                  url: Optional[_builtins.str] = None):
         """
         :param _builtins.str hostname: The host to dial to initiate a connection from the egress node to this resource.
@@ -46638,6 +47135,8 @@ class GetResourceResourceMcpGatewayPatResult(dict):
         :param _builtins.str secret_store_id: ID of the secret store containing credentials for this resource, if any.
         :param _builtins.str subdomain: DNS subdomain through which this resource may be accessed on clients.  (e.g. "app-prod1" allows the resource to be accessed at "app-prod1.your-org-name.sdm-proxy-domain"). Only applicable to HTTP-based resources or resources using virtual networking mode.
         :param Mapping[str, _builtins.str] tags: Tags is a map of key, value pairs.
+        :param _builtins.str tls_cert: Custom TLS certificate for upstream connection.
+        :param _builtins.bool tls_insecure: Skip TLS certificate verification for the upstream connection.
         :param _builtins.str url: The URL to dial to initiate a connection from the egress node to this resource.
                * memcached:
         """
@@ -46662,6 +47161,10 @@ class GetResourceResourceMcpGatewayPatResult(dict):
             pulumi.set(__self__, "subdomain", subdomain)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if tls_cert is not None:
+            pulumi.set(__self__, "tls_cert", tls_cert)
+        if tls_insecure is not None:
+            pulumi.set(__self__, "tls_insecure", tls_insecure)
         if url is not None:
             pulumi.set(__self__, "url", url)
 
@@ -46752,6 +47255,22 @@ class GetResourceResourceMcpGatewayPatResult(dict):
         Tags is a map of key, value pairs.
         """
         return pulumi.get(self, "tags")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsCert")
+    def tls_cert(self) -> Optional[_builtins.str]:
+        """
+        Custom TLS certificate for upstream connection.
+        """
+        return pulumi.get(self, "tls_cert")
+
+    @_builtins.property
+    @pulumi.getter(name="tlsInsecure")
+    def tls_insecure(self) -> Optional[_builtins.bool]:
+        """
+        Skip TLS certificate verification for the upstream connection.
+        """
+        return pulumi.get(self, "tls_insecure")
 
     @_builtins.property
     @pulumi.getter


### PR DESCRIPTION
## Summary
- Bumps `github.com/strongdm/terraform-provider-sdm` to a newer commit, adding `tlsCert` and `tlsInsecure` fields for upstream TLS connections across several resource types (memcached, redis, and related resources).
- Regenerates the Go, Node.js, Python, and .NET SDKs from the updated schema.

## Test plan
- [ ] `make build_sdks` runs clean
- [ ] `make lint_provider` passes
- [ ] Manual smoke test against a resource using the new `tlsCert`/`tlsInsecure` fields